### PR TITLE
Changed Alpha characters

### DIFF
--- a/MD5.cpp
+++ b/MD5.cpp
@@ -9,7 +9,7 @@ MD5::MD5()
 char* MD5::make_digest(const unsigned char *digest, int len) /* {{{ */
 {
 	char * md5str = (char*) malloc(sizeof(char)*(len*2+1));
-	static const char hexits[17] = "0123456789ABCDEF";
+	static const char hexits[17] = "0123456789abcdef";
 	int i;
 
 	for (i = 0; i < len; i++) {


### PR DESCRIPTION
Had a problem concatenating md5 hashes for HTTP Digest algorithm and creating another md5 hash from that where the output was would lead to unexpected results.  Changing the Alpha characters to lower case resolved the issue.  See my email for more on this.
