### PR TITLE
Fix for Bytearrays with Zero Bytes

### DIFF
--- a/MD5.cpp
+++ b/MD5.cpp
@@ -287,4 +287,13 @@ unsigned char* MD5::make_hash(char *arg)
 	MD5Final(hash, &context);
 	return hash;
 }
+unsigned char* MD5::make_hash(char *arg,size_t size)
+{
+	MD5_CTX context;
+	unsigned char * hash = (unsigned char *) malloc(16);
+	MD5Init(&context);
+	MD5Update(&context, arg, size);
+	MD5Final(hash, &context);
+	return hash;
+}
 

--- a/MD5.cpp
+++ b/MD5.cpp
@@ -287,4 +287,14 @@ unsigned char* MD5::make_hash(char *arg)
 	MD5Final(hash, &context);
 	return hash;
 }
+unsigned char* MD5::make_hash_bytes(char *arg,size_t size)
+{
+	MD5_CTX context;
+	unsigned char * hash = (unsigned char *) malloc(16);
+	MD5Init(&context);
+	MD5Update(&context, arg, size);
+	MD5Final(hash, &context);
+	return hash;
+}
+
 

--- a/MD5.cpp
+++ b/MD5.cpp
@@ -287,14 +287,4 @@ unsigned char* MD5::make_hash(char *arg)
 	MD5Final(hash, &context);
 	return hash;
 }
-unsigned char* MD5::make_hash_bytes(char *arg,size_t size)
-{
-	MD5_CTX context;
-	unsigned char * hash = (unsigned char *) malloc(16);
-	MD5Init(&context);
-	MD5Update(&context, arg, size);
-	MD5Final(hash, &context);
-	return hash;
-}
-
 

--- a/MD5.h
+++ b/MD5.h
@@ -41,6 +41,7 @@ class MD5
 public:
 	MD5();
 	static unsigned char* make_hash(char *arg);
+	static unsigned char* make_hash(char *arg,size_t size);
 	static char* make_digest(const unsigned char *digest, int len);
  	static const void *body(void *ctxBuf, const void *data, size_t size);
 	static void MD5Init(void *ctxBuf);

--- a/MD5.h
+++ b/MD5.h
@@ -41,7 +41,6 @@ class MD5
 public:
 	MD5();
 	static unsigned char* make_hash(char *arg);
-	static unsigned char* make_hash_bytes(char *arg,size_t size);
 	static char* make_digest(const unsigned char *digest, int len);
  	static const void *body(void *ctxBuf, const void *data, size_t size);
 	static void MD5Init(void *ctxBuf);

--- a/MD5.h
+++ b/MD5.h
@@ -41,6 +41,7 @@ class MD5
 public:
 	MD5();
 	static unsigned char* make_hash(char *arg);
+	static unsigned char* make_hash_bytes(char *arg,size_t size);
 	static char* make_digest(const unsigned char *digest, int len);
  	static const void *body(void *ctxBuf, const void *data, size_t size);
 	static void MD5Init(void *ctxBuf);


### PR DESCRIPTION
strlen stops on first zerobyte, mismatched hash.